### PR TITLE
Allow inherits dependency to be latest compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "node test/node/*.js && zuul test/browser/*.js"
   },
   "dependencies": {
-    "inherits": "2.0.1"
+    "inherits": "^2.0.1"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "node test/node/*.js && zuul test/browser/*.js"
   },
   "dependencies": {
-    "inherits": "^2.0.1"
+    "inherits": "2.0.3"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Corrects #17 (Outdated inherits cause trouble upstream; Webpack 2) 