### PR TITLE
Allow inherits dependency to be latest compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "zuul": "^3.0.0"
+    "zuul": "~3.11.0"
   },
   "browser": {
     "./support/isBuffer.js": "./support/isBufferBrowser.js"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "node test/node/*.js && zuul test/browser/*.js"
   },
   "dependencies": {
-    "inherits": "^2.0.1"
+    "inherits": "~2.0.1"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "node test/node/*.js && zuul test/browser/*.js"
   },
   "dependencies": {
-    "inherits": "2.0.1"
+    "inherits": "^2.0.1"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "zuul": "~1.0.9"
+    "zuul": "^3.0.0"
   },
   "browser": {
     "./support/isBuffer.js": "./support/isBufferBrowser.js"


### PR DESCRIPTION
@defunctzombie @bdjnk This is picking up from your PR [here](https://github.com/defunctzombie/node-util/pull/18).  I was able to get `zuul` to pass locally - not sure if this will pass the CI test or not but opening this PR will at least get this running.