### PR TITLE
Fix callbackify on old Node.js

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,10 +1,14 @@
 browsers:
   - name: chrome
-    version: 27..latest
+    version:
+      - 49 # last supported on XP (keep it so long as it's easy to support)
+      - -1..latest
   - name: firefox
-    version: latest
+    version:
+      - 52 # extended support release
+      - -1..latest
   - name: safari
-    version: latest
+    version: -1..latest
   - name: ie
     version: 9..latest
 sauce_connect: true

--- a/test/node/callbackify.js
+++ b/test/node/callbackify.js
@@ -8,6 +8,11 @@ var assert = require('assert');
 var callbackify = require('../../').callbackify;
 var execFile = require('child_process').execFile;
 
+if (typeof Promise === 'undefined') {
+  console.log('no global Promise found, skipping callbackify tests');
+  return;
+}
+
 var values = [
   'hello world',
   null,

--- a/test/node/callbackify.js
+++ b/test/node/callbackify.js
@@ -72,7 +72,7 @@ if (typeof Symbol !== 'undefined') {
           assert.strictEqual(err.message, 'Promise was rejected with a falsy value');
           assert.strictEqual(err.reason, value);
         } else {
-          assert.strictEqual(String(value).endsWith(err.message), true);
+          assert.strictEqual(String(value).slice(-err.message.length), err.message);
         }
       } else {
         assert.strictEqual(err, value);
@@ -97,7 +97,7 @@ if (typeof Symbol !== 'undefined') {
           assert.strictEqual(err.message, 'Promise was rejected with a falsy value');
           assert.strictEqual(err.reason, value);
         } else {
-          assert.strictEqual(String(value).endsWith(err.message), true);
+          assert.strictEqual(String(value).slice(-err.message.length), err.message);
         }
       } else {
         assert.strictEqual(err, value);

--- a/util.js
+++ b/util.js
@@ -691,8 +691,8 @@ function callbackify(original) {
     // In true node style we process the callback on `nextTick` with all the
     // implications (stack, `uncaughtException`, `async_hooks`)
     original.apply(this, args)
-      .then(function(ret) { process.nextTick(cb, null, ret) },
-            function(rej) { process.nextTick(callbackifyOnRejected, rej, cb) });
+      .then(function(ret) { process.nextTick(cb.bind(null, null, ret)) },
+            function(rej) { process.nextTick(callbackifyOnRejected.bind(null, rej, cb)) });
   }
 
   Object.setPrototypeOf(callbackified, Object.getPrototypeOf(original));


### PR DESCRIPTION
And remove like 30 versions of Chrome from the test matrix

`process.nextTick` didn't support passing additional arguments separately before Node 1.8 or something. This patch uses `.bind()` to pass them in instead.