### PR TITLE
Don't assume process.env exists in the global scope.

### DIFF
--- a/util.js
+++ b/util.js
@@ -106,7 +106,7 @@ exports.deprecate = function(fn, msg) {
 var debugs = {};
 var debugEnvRegex = /^$/;
 
-if (typeof process !== 'undefined' && process.env && process.env.NODE_DEBUG) {
+if (typeof process !== 'undefined' && process.env.NODE_DEBUG) {
   var debugEnv = process.env.NODE_DEBUG;
   debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
     .replace(/\*/g, '.*')

--- a/util.js
+++ b/util.js
@@ -106,7 +106,7 @@ exports.deprecate = function(fn, msg) {
 var debugs = {};
 var debugEnvRegex = /^$/;
 
-if (process.env.NODE_DEBUG) {
+if (typeof process !== 'undefined' && process.env && process.env.NODE_DEBUG) {
   var debugEnv = process.env.NODE_DEBUG;
   debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
     .replace(/\*/g, '.*')


### PR DESCRIPTION
Some platforms may not have process.env in the global scope and this shouldn't prevent util from running. Currently it will thrown an exception on import if process.env doesn't exist.