### PR TITLE
fix: callbackify resulting function should have one more argument

### DIFF
--- a/support/isFunctionLengthConfigurable.js
+++ b/support/isFunctionLengthConfigurable.js
@@ -1,0 +1,4 @@
+
+module.exports = function isFunctionLengthConfigurable(arg) {
+    return Object.getOwnPropertyDescriptor(function () { }, 'length').configurable;
+}

--- a/support/nodeJSVersion.js
+++ b/support/nodeJSVersion.js
@@ -1,0 +1,8 @@
+
+module.exports = function nodeJSVersion(arg) {
+
+    if (!process || !process.version || !process.version.match(/^v(\d+)\.(\d+)/)) {
+        return false;
+    }
+    return parseInt(process.version.split('.')[0].slice(1), 10); 
+}

--- a/test/browser/callbackify.js
+++ b/test/browser/callbackify.js
@@ -167,3 +167,18 @@ test('util.callbackify non-function inputs throw', function (t) {
   });
   t.end();
 });
+
+test('util.callbackify resulting function should have one more argument', function (t) {
+  // Test that resulting function should have one more argument
+  [
+    function() { },
+    function(a) { },
+    function(a, b) { }
+  ].forEach(function (fct) {
+
+    var callbackified = callbackify(fct);
+    t.strictEqual(callbackified.length, fct.length + 1, "callbackified function should have one more argument");
+  });
+  t.end();
+});
+

--- a/test/browser/callbackify.js
+++ b/test/browser/callbackify.js
@@ -3,6 +3,8 @@
 var test = require('tape');
 var callbackify = require('../../').callbackify;
 
+var isFunctionLengthConfigurable = require('../../support/isFunctionLengthConfigurable');
+
 if (typeof Promise === 'undefined') {
   console.log('no global Promise found, skipping callbackify tests');
   return;
@@ -169,6 +171,11 @@ test('util.callbackify non-function inputs throw', function (t) {
 });
 
 test('util.callbackify resulting function should have one more argument', function (t) {
+
+  if (!isFunctionLengthConfigurable()) {
+    console.log("skipping this test as function.length is not configurable in the current javascript engine");
+    return;
+  }
   // Test that resulting function should have one more argument
   [
     function() { },

--- a/test/node/callbackify.js
+++ b/test/node/callbackify.js
@@ -193,3 +193,29 @@ if (false) {
 if (require('is-async-supported')()) {
   require('./callbackify-async');
 }
+
+(function callbackify_resulting_function_should_have_one_more_argument() {
+
+  var nodeJSVersion = parseInt(process.version.substring(1,3),10);
+
+  console.log("Testing callbackify resulting function should have one more argument")
+  var original_callbackify = require('util').callbackify;
+  // Test that resulting function should have one more argument
+  [
+    function(){ },
+    function(a){ }, 
+    function(a, b) { }
+  ].forEach(function (fct) {
+
+    var node_callbackified = original_callbackify(fct);
+    var browser_callbackified = callbackify(fct);
+
+    if (nodeJSVersion >= 12 && node_callbackified.length !== fct.length + 1) {
+      // this behavior is only true with node 12 and above, where the bug was fixed
+      throw new Error("callbackified function should have one more argument");
+    }
+    if (browser_callbackified.length !== node_callbackified.length) {
+      throw new Error("callbackified function should have one more argument, like in node");
+    }
+  });
+})();

--- a/util.js
+++ b/util.js
@@ -708,8 +708,9 @@ function callbackify(original) {
   }
 
   Object.setPrototypeOf(callbackified, Object.getPrototypeOf(original));
-  Object.defineProperties(callbackified,
-                          getOwnPropertyDescriptors(original));
+  const desc = getOwnPropertyDescriptors(original);
+  desc.length.value += 1;
+  Object.defineProperties(callbackified, desc);
   return callbackified;
 }
 exports.callbackify = callbackify;


### PR DESCRIPTION
Fixing a callbackify behavior that is different from the NodeJS implementation ( when NodeJS version >= 12.0)

In node, the callbackified function has a length that is one more than the length of the original function. For instance:

         callbackify((a,b,c)=>Promise<void>).length = 4 

this is not the case in the current version (<=0.12.4) where 
  
       callbackify((a,b,c)=>Promise<void>).length = 3 

This PR provides the fix and the associated unit test.
